### PR TITLE
feat: add newman

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,11 @@ COPY ai-vitals/src ./src
 # Build the application
 RUN cargo build --release
 
-# Runtime stage - use Ubuntu for better compatibility
-FROM ubuntu:22.04
+FROM node
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
+
+# Install newman globally
+RUN npm install -g newman
 
 # Copy the binary from builder stage
 COPY --from=builder /app/target/release/ai-vitals /app/ai-vitals

--- a/README.md
+++ b/README.md
@@ -1,10 +1,21 @@
 # Model Monitor
 
-A helm chart and rust library for **actively** monitoring [OpenAI-compatible API](https://platform.openai.com/docs/api-reference/introduction) endpoints using [Cronitor](https://cronitor.io).
+A helm chart and rust library for **actively** monitoring API endpoints and reporting results to an exporter.
+
+Currently supported Probes:
+
+* [OpenAI-compatible](https://platform.openai.com/docs/api-reference/introduction) API: Chat Completion, Embedding
+* [Newman](https://www.npmjs.com/package/newman): Run Postman collections
+
+Currently supported exporters:
+
+* [Cronitor](https://cronitor.io/)
+
+Make an [issue](https://github.com/doublewordai/model-monitor/issues) if you have requests for additional probes or exporters.
 
 ## Overview
 
 The repository consists of two main components:
 
-1. **[AI Vitals](./ai-vitals/README.md)**: A Rust library that provides a CLI and programmatic interface to monitor LLM endpoints and report their status to Cronitor.
+1. **[AI Vitals](./ai-vitals/README.md)**: A Rust library that provides a CLI and programmatic interface to probe endpoints and report their status to exporters.
 2. **[Helm Chart](./helm/README.md)**: A Helm chart that deploys CronJobs to periodically test the health of these endpoints.

--- a/ai-vitals/Cargo.lock
+++ b/ai-vitals/Cargo.lock
@@ -39,6 +39,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tokio-test",
  "tracing",
@@ -2205,15 +2206,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.20.0"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/ai-vitals/Cargo.lock
+++ b/ai-vitals/Cargo.lock
@@ -31,6 +31,7 @@ name = "ai-vitals"
 version = "0.7.1"
 dependencies = [
  "anyhow",
+ "async-trait",
  "chrono",
  "clap",
  "hostname",
@@ -329,9 +330,9 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.88"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/ai-vitals/Cargo.toml
+++ b/ai-vitals/Cargo.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 
 [dependencies]
 anyhow   = "1"
+async-trait = "0.1.89"
 chrono   = { version = "0.4", default-features = false, features = ["clock"] }
 clap     = { version = "4", features = ["derive", "env"] }
 hostname = "0.4.1"

--- a/ai-vitals/Cargo.toml
+++ b/ai-vitals/Cargo.toml
@@ -25,4 +25,5 @@ urlencoding = "2.1.3"
 
 [dev-dependencies]
 httpmock = "0.7"
+tempfile = "3.23"
 tokio-test = "0.4"

--- a/ai-vitals/src/lib.rs
+++ b/ai-vitals/src/lib.rs
@@ -1,22 +1,38 @@
 //! # ai-vitals
 //!
 //! A monitoring tool for LLM endpoints that reports status to Cronitor.
-//!
+//! 
+//! The library is split into a few main components:
+//! 
+//! * monitor: Entrypoint for running the monitoring process. It orchestrates the probing of endpoints and exporting results.
+//! * cli: Handles command-line argument parsing and configuration setup.
+//! * probes: Contains implementations for probing different types of endpoints, such as OpenAI chat completions and embeddings.
+//! * exporters: Contains implementations for exporting monitoring results to different services, currently only Cronitor.
+//! 
 //! ## Running Tests
-//!
+//! 
 //! ```bash
 //! cargo test
 //! ```
-use anyhow::{Context, Result};
-use chrono::Utc;
-use clap::Parser;
-use hostname::get;
-use reqwest::Client;
-use serde_json::json;
-use std::time::Duration;
+use anyhow::Result;
 use tracing::{error, info};
 
-/// State of a Cronitor ping
+/// Result of an LLM endpoint probe
+#[derive(Debug, PartialEq)]
+pub enum ProbeResult {
+    Success,
+    HttpError(u16),
+    Timeout,
+    NetworkError(String),
+}
+
+#[async_trait::async_trait]
+pub trait Probe {
+    fn new(config: cli::Config) -> Result<Self> where Self: std::marker::Sized;
+    async fn probe(&self) -> ProbeResult;
+}
+
+/// State of a Export ping
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum PingState {
     Run,
@@ -34,348 +50,51 @@ impl PingState {
     }
 }
 
-/// Type of LLM endpoint to probe
-#[derive(Debug, Clone, Copy, PartialEq, clap::ValueEnum)]
-pub enum EndpointType {
-    #[value(name = "chat")]
-    ChatCompletion,
-    #[value(name = "embedding")]
-    Embedding,
+#[async_trait::async_trait]
+pub trait Export {
+    fn new(config: cli::Config) -> Result<Self> where Self: std::marker::Sized;
+    async fn ping(&self, state: PingState, status_code: u16, message: Option<&str>);
 }
 
-/// Configuration for the monitoring tool
-#[derive(Parser, Debug, Clone, PartialEq)]
-#[command(
-    author,
-    version,
-    about,
-    long_about = "Probe an LLM endpoint and report status to Cronitor."
-)]
-pub struct Config {
-    /// Base URL for Cronitor, e.g. https://cronitor.link
-    #[arg(long, env = "CRONITOR_BASE_URL")]
-    pub cronitor_base_url: String,
-
-    /// Base URL for Cronitor, e.g. https://cronitor.link
-    #[arg(long, env = "CRONITOR_API_KEY")]
-    pub cronitor_api_key: Option<String>,
-
-    /// Monitor name / code in Cronitor
-    #[arg(long, env = "MONITOR_NAME")]
-    pub monitor_name: String,
-
-    /// Base URL of the server to probe, e.g. https://my-openai-proxy
-    #[arg(long, env = "SERVER_URL")]
-    pub server_url: String,
-
-    /// "chat" or "embedding"
-    #[arg(long, env = "ENDPOINT_TYPE")]
-    pub endpoint_type: EndpointType,
-
-    /// Name of the model to query
-    #[arg(long, env = "MODEL_NAME")]
-    pub model_name: String,
-
-    /// Environment descriptor (defaults to "production")
-    #[arg(long, env = "APP_ENV", default_value = "production")]
-    pub env: String,
-
-    /// Request timeout in seconds (default 10)
-    #[arg(long, env = "TIMEOUT_SECONDS", default_value_t = 10)]
-    pub timeout_seconds: u64,
-
-    
-    /// The below all require an API key to be set to take effect.
-
-    /// minFreqRequiredMins catches inactive alerts - if an alert starts but never completes, 
-    /// it'll be marked as inactive by Cronitor. To force this into raising an alert,
-    /// we require a successful ping once per any minFreqRequiredMins period. 
-    #[arg(long, env = "MIN_SUCCESS_FREQ")]
-    pub min_success_freq: Option<u8>,
-    
-    
-    /// Which schedule to display in the frontend and to guide CONSECUTIVE_FAILURES_FOR_ALERT.
-    #[arg(long, env = "SCHEDULE")]
-    pub schedule: Option<String>,
-    
-    /// Optional: how many failed pings are needed to trigger an alert. Cronitor assumes 1 if unset.
-    #[arg(long, env = "CONSECUTIVE_FAILURES_FOR_ALERT")]
-    pub consecutive_failures: Option<u8>,
-
-    /// Optional: how many missing pings are needed to trigger an alert. Cronitor disables this
-    /// unless specified here as > 0. Requires schedule to be set.
-    #[arg(long, env = "CONSECUTIVE_MISSING_FOR_ALERT")]
-    pub consecutive_missing: Option<u8>,
-
-    /// Optional: Group to put monitor in, mostly for frontend viewing.
-    #[arg(long, env = "MONITOR_GROUP")]
-    pub monitor_group: Option<String>,
-}
-
-impl Default for Config {
-    fn default() -> Self {
-        Config {
-            cronitor_base_url: "https://cronitor.link".to_string(),
-            cronitor_api_key: None,
-            monitor_name: "test-monitor".to_string(),
-            server_url: "https://api.openai.com".to_string(),
-            endpoint_type: EndpointType::ChatCompletion,
-            model_name: "gpt-4".to_string(),
-            env: "test".to_string(),
-            timeout_seconds: 10,
-            schedule: Option::from("*/5 * * * *".to_string()),
-            consecutive_failures: Some(1),
-            min_success_freq: Some(60),
-            monitor_group: None,
-            consecutive_missing: Some(1),
-        }
-    }
-}
-
-/// Result of an LLM endpoint probe
-#[derive(Debug, PartialEq)]
-pub enum ProbeResult {
-    Success,
-    HttpError(u16),
-    Timeout,
-    NetworkError(String),
-}
-
-/// Cronitor client to send pings
-pub struct CronitorClient {
-    config: Config,
-    client: Client,
-    host: String,
-    series_id: String,
-}
-
-impl CronitorClient {
-    pub fn new(config: Config) -> Result<Self> {
-        let client = Client::builder()
-            .timeout(Duration::from_secs(config.timeout_seconds))
-            .build()
-            .context("building reqwest client")?;
-
-        let host = get().unwrap_or_default().to_string_lossy().into_owned();
-        let series_id = format!("{}-{}", Utc::now().timestamp(), std::process::id());
-
-        info!("Starting job with series ID: {series_id}");
-
-        Ok(CronitorClient {
-            config,
-            client,
-            host,
-            series_id,
-        })
-    }
-
-    pub fn build_ping_url(
-        &self,
-        state: PingState,
-        status_code: u16,
-        message: Option<&str>,
-    ) -> String {
-        let mut url = format!(
-            "{}/{}?state={}&series={}&status_code={}&env={}&host={}",
-            self.config.cronitor_base_url,
-            self.config.monitor_name,
-            state.as_str(),
-            self.series_id,
-            status_code,
-            self.config.env,
-            self.host
-        );
-        if let Some(msg) = message {
-            url.push_str("&message=");
-            url.push_str(&urlencoding::encode(msg));
-        }
-        url
-    }
-
-    pub async fn ping(&self, state: PingState, status_code: u16, message: Option<&str>) {
-        let url = self.build_ping_url(state, status_code, message);
-
-        match self.client.get(&url).send().await {
-            Ok(resp) if resp.status().is_success() => {
-                // success: optionally peek at body for debugging
-                info!("Cronitor ping OK");
-            }
-            Ok(resp) => {
-                // non-2xx: log status + response body (often has the reason)
-                let status = resp.status();
-                let body = resp.text().await.unwrap_or_default(); // consumes resp
-                error!("Cronitor ping non-2xx {status}: {body}");
-            }
-            Err(e) => {
-                // request failed before a response was received
-                error!("Failed to send ping to Cronitor: {e}");
-            }
-        }
-
-        if state == PingState::Run {
-            // The above handles the ping. We also want to update the created monitor if we can.
-
-            let Some(api_key) = self.config.cronitor_api_key.as_deref() else {
-                info!("No api key, skipping monitor enrichment");
-                return; // no key => skip update
-            };
-
-            match self
-                .client
-                .put("https://cronitor.io/api/monitors")
-                .basic_auth(api_key, Some("")) // username = API key, blank password
-                .json(&self.get_monitor_update_payload())
-                .send()
-                .await
-            {
-                Ok(resp) if resp.status().is_success() => {
-                    info!("Monitor enriched successful");
-                }
-                Ok(resp) => {
-                    if !resp.status().is_success() {
-                        error!(
-                            "Monitor enrichment failed {}: {}",
-                            resp.status(),
-                            resp.text().await.unwrap_or_default()
-                        );
-                    }
-                }
-                Err(err) => {
-                    error!("Failed to enrich Cronitor monitor: {err}");
-                }
-            }
-        }
-    }
-
-    pub fn get_monitor_update_payload(&self) -> serde_json::Value {
-        let mut monitor = serde_json::Map::new();
-        monitor.insert("type".into(), json!("job"));
-        monitor.insert("key".into(), json!(self.config.monitor_name));
-
-        if let Some(consecutive_failures) = self.config.consecutive_failures.clone() {
-            monitor.insert("failure_tolerance".into(), json!(consecutive_failures));
-        }
-
-        if let Some(schedule) = self.config.schedule.clone() {
-            monitor.insert("schedule".into(), json!(schedule));
-        }
-
-        
-        if let (Some(consecutive_missing), Some(_)) = (self.config.consecutive_missing, self.config.schedule.clone()) {
-            monitor.insert("schedule_tolerance".into(), json!(consecutive_missing));
-        }
-        
-        if let Some(group) = self.config.monitor_group.clone() {
-            monitor.insert("group".into(), json!(group));
-        }
-
-        // always include the duration assertion
-        let mut assertions: Vec<String> = vec![format!(
-            "metric.duration < {}s",
-            self.config.timeout_seconds * 2
-        )];
-
-        if let Some(min_success_freq) = self.config.min_success_freq.clone() {
-            assertions.push(format!("job.completes < {} minute", min_success_freq));
-        }
-        monitor.insert("assertions".into(), json!(assertions));
-
-        json!({ "monitors": [serde_json::Value::Object(monitor)] })
-    }
-}
-
-/// LLM endpoint probe functionality
-pub struct LLMProbe {
-    client: Client,
-    config: Config,
-}
-
-impl LLMProbe {
-    pub fn new(config: Config) -> Result<Self> {
-        let client = Client::builder()
-            .timeout(Duration::from_secs(config.timeout_seconds))
-            .build()
-            .context("building reqwest client")?;
-
-        Ok(LLMProbe { client, config })
-    }
-
-    pub fn build_endpoint_url(&self) -> String {
-        match self.config.endpoint_type {
-            EndpointType::ChatCompletion => {
-                format!("{}/v1/chat/completions", self.config.server_url)
-            }
-            EndpointType::Embedding => format!("{}/v1/embeddings", self.config.server_url),
-        }
-    }
-
-    pub fn build_payload(&self) -> serde_json::Value {
-        match self.config.endpoint_type {
-            EndpointType::ChatCompletion => json!({
-                "model": self.config.model_name,
-                "messages": [{ "role": "user", "content": "test" }],
-                "max_tokens": 1,
-                "priority": -100
-            }),
-            EndpointType::Embedding => json!({
-                "model": self.config.model_name,
-                "input": "test",
-                "priority": -100
-            }),
-        }
-    }
-
-    pub async fn probe(&self) -> ProbeResult {
-        let endpoint = self.build_endpoint_url();
-        let payload = self.build_payload();
-
-        info!("Querying {endpoint}");
-
-        match self.client.post(&endpoint).json(&payload).send().await {
-            Ok(resp) => {
-                let status = resp.status();
-                let body = resp.text().await.unwrap_or_default();
-                info!("Response body: {body}");
-
-                if status.is_success() {
-                    ProbeResult::Success
-                } else {
-                    ProbeResult::HttpError(status.as_u16())
-                }
-            }
-            Err(e) if e.is_timeout() => ProbeResult::Timeout,
-            Err(e) => ProbeResult::NetworkError(e.to_string()),
-        }
-    }
-}
-
-/// Main monitoring orchestrator
+/// Main monitoring orchestrator.
+/// 
+/// It holds the exporter and probe implementations and runs the monitoring process.
 pub struct Monitor {
-    cronitor_client: CronitorClient,
-    llm_probe: LLMProbe,
+    exporter: Box<dyn Export>,
+    probe: Box<dyn Probe>,
 }
 
 impl Monitor {
-    pub fn new(config: Config) -> Result<Self> {
-        let cronitor_client = CronitorClient::new(config.clone())?;
-        let llm_probe = LLMProbe::new(config)?;
+    pub fn new(config: cli::Config) -> Result<Self> {
+        let exporter = exporters::Cronitor::new(config.clone())?;
+        let llm_probe = match config.endpoint_type {
+            probes::Type::OpenAIChatCompletion | probes::Type::OpenAIEmbedding => {
+                probes::OpenAI::new(config.clone())?
+            }
+            _ => {
+                return Err(anyhow::anyhow!(
+                    "Unsupported endpoint type: {:?}",
+                    config.endpoint_type
+                ))
+            }
+        };
 
         Ok(Monitor {
-            cronitor_client,
-            llm_probe,
+            exporter: Box::new(exporter),
+            probe: Box::new(llm_probe),
         })
     }
 
     pub async fn run(&self) -> i32 {
         // Send start ping
         info!("Sending start ping to Cronitor");
-        self.cronitor_client.ping(PingState::Run, 0, None).await;
+        self.exporter.ping(PingState::Run, 0, None).await;
 
         // Probe the endpoint
-        match self.llm_probe.probe().await {
+        match self.probe.probe().await {
             ProbeResult::Success => {
                 info!("Sending success ping to Cronitor");
-                self.cronitor_client
+                self.exporter
                     .ping(PingState::Complete, 0, None)
                     .await;
                 info!("SUCCESS: Endpoint responded successfully");
@@ -383,7 +102,7 @@ impl Monitor {
             }
             ProbeResult::HttpError(status_code) => {
                 info!("Sending failure ping to Cronitor");
-                self.cronitor_client
+                self.exporter
                     .ping(PingState::Fail, status_code, None)
                     .await;
                 error!("FAILURE: Endpoint failed with HTTP {status_code}");
@@ -391,7 +110,7 @@ impl Monitor {
             }
             ProbeResult::Timeout => {
                 info!("Sending timeout ping to Cronitor");
-                self.cronitor_client
+                self.exporter
                     .ping(PingState::Fail, 124, Some("Request timeout"))
                     .await;
                 error!("TIMEOUT: Request timed out");
@@ -399,7 +118,7 @@ impl Monitor {
             }
             ProbeResult::NetworkError(error) => {
                 info!("Sending failure ping to Cronitor");
-                self.cronitor_client
+                self.exporter
                     .ping(PingState::Fail, 1, Some(&format!("Network error: {error}")))
                     .await;
                 error!("FAILURE: Network error: {error}");
@@ -409,23 +128,381 @@ impl Monitor {
     }
 }
 
+pub mod cli {
+    use clap::Parser;
+
+    use super::probes::Type as ProbeType;
+
+    /// Configuration for the monitoring tool
+    #[derive(Parser, Debug, Clone, PartialEq)]
+    #[command(
+        author,
+        version,
+        about,
+        long_about = "Probe an LLM endpoint and report status to Cronitor."
+    )]
+    pub struct Config {
+        /// Base URL for Cronitor, e.g. https://cronitor.link
+        #[arg(long, env = "CRONITOR_BASE_URL")]
+        pub cronitor_base_url: String,
+
+        /// Base URL for Cronitor, e.g. https://cronitor.link
+        #[arg(long, env = "CRONITOR_API_KEY")]
+        pub cronitor_api_key: Option<String>,
+
+        /// Monitor name / code in Cronitor
+        #[arg(long, env = "MONITOR_NAME")]
+        pub monitor_name: String,
+
+        /// Base URL of the server to probe, e.g. https://my-openai-proxy
+        #[arg(long, env = "SERVER_URL")]
+        pub server_url: String,
+
+        /// Optional: Probe type to use for the probe. Currently only "llm" is supported.
+        #[arg(long, env = "ENDPOINT_TYPE", default_value = ProbeType::OpenAIChatCompletion)]
+        pub endpoint_type: ProbeType,
+
+        /// Name of the model to query
+        #[arg(long, env = "MODEL_NAME")]
+        pub model_name: String,
+
+        /// Environment descriptor (defaults to "production")
+        #[arg(long, env = "APP_ENV", default_value = "production")]
+        pub env: String,
+
+        /// Request timeout in seconds (default 10)
+        #[arg(long, env = "TIMEOUT_SECONDS", default_value_t = 10)]
+        pub timeout_seconds: u64,
+        
+        /// The below all require an API key to be set to take effect.
+
+        /// minFreqRequiredMins catches inactive alerts - if an alert starts but never completes, 
+        /// it'll be marked as inactive by Cronitor. To force this into raising an alert,
+        /// we require a successful ping once per any minFreqRequiredMins period. 
+        #[arg(long, env = "MIN_SUCCESS_FREQ")]
+        pub min_success_freq: Option<u8>,
+        
+        /// Which schedule to display in the frontend and to guide CONSECUTIVE_FAILURES_FOR_ALERT.
+        #[arg(long, env = "SCHEDULE")]
+        pub schedule: Option<String>,
+        
+        /// Optional: how many failed pings are needed to trigger an alert. Cronitor assumes 1 if unset.
+        #[arg(long, env = "CONSECUTIVE_FAILURES_FOR_ALERT")]
+        pub consecutive_failures: Option<u8>,
+
+        /// Optional: how many missing pings are needed to trigger an alert. Cronitor disables this
+        /// unless specified here as > 0. Requires schedule to be set.
+        #[arg(long, env = "CONSECUTIVE_MISSING_FOR_ALERT")]
+        pub consecutive_missing: Option<u8>,
+
+        /// Optional: Group to put monitor in, mostly for frontend viewing.
+        #[arg(long, env = "MONITOR_GROUP")]
+        pub monitor_group: Option<String>,
+    }
+
+    impl Default for Config {
+        fn default() -> Self {
+            Config {
+                cronitor_base_url: "https://cronitor.link".to_string(),
+                cronitor_api_key: None,
+                monitor_name: "test-monitor".to_string(),
+                server_url: "https://api.openai.com".to_string(),
+                endpoint_type: ProbeType::OpenAIChatCompletion,
+                model_name: "gpt-4".to_string(),
+                env: "test".to_string(),
+                timeout_seconds: 10,
+                schedule: Option::from("*/5 * * * *".to_string()),
+                consecutive_failures: Some(1),
+                min_success_freq: Some(60),
+                monitor_group: None,
+                consecutive_missing: Some(1),
+            }
+        }
+    }
+}
+
+pub mod exporters {
+    use anyhow::{Context, Result};
+    use chrono::Utc;
+    use hostname::get;
+    use reqwest::Client;
+    use serde_json::json;
+    use std::time::Duration;
+    use tracing::{error, info};
+
+    use crate::Export;
+
+    use super::{cli::Config, PingState};
+
+    /// Cronitor client to send pings
+    pub struct Cronitor {
+        config: Config,
+        client: Client,
+        host: String,
+        series_id: String,
+    }
+
+    /// Cronitor exporter implementation
+    #[async_trait::async_trait]
+    impl Export for Cronitor {
+        fn new(config: Config) -> Result<Self> {
+            let client = Client::builder()
+                .timeout(Duration::from_secs(config.timeout_seconds))
+                .build()
+                .context("building reqwest client")?;
+
+            let host = get().unwrap_or_default().to_string_lossy().into_owned();
+            let series_id = format!("{}-{}", Utc::now().timestamp(), std::process::id());
+
+            info!("Starting job with series ID: {series_id}");
+
+            Ok(Cronitor {
+                config,
+                client,
+                host,
+                series_id,
+            })
+        }
+
+        async fn ping(&self, state: PingState, status_code: u16, message: Option<&str>) {
+            let url = self.build_ping_url(state, status_code, message);
+
+            match self.client.get(&url).send().await {
+                Ok(resp) if resp.status().is_success() => {
+                    // success: optionally peek at body for debugging
+                    info!("Cronitor ping OK");
+                }
+                Ok(resp) => {
+                    // non-2xx: log status + response body (often has the reason)
+                    let status = resp.status();
+                    let body = resp.text().await.unwrap_or_default(); // consumes resp
+                    error!("Cronitor ping non-2xx {status}: {body}");
+                }
+                Err(e) => {
+                    // request failed before a response was received
+                    error!("Failed to send ping to Cronitor: {e}");
+                }
+            }
+
+            if state == PingState::Run {
+                // The above handles the ping. We also want to update the created monitor if we can.
+
+                let Some(api_key) = self.config.cronitor_api_key.as_deref() else {
+                    info!("No api key, skipping monitor enrichment");
+                    return; // no key => skip update
+                };
+
+                match self
+                    .client
+                    .put("https://cronitor.io/api/monitors")
+                    .basic_auth(api_key, Some("")) // username = API key, blank password
+                    .json(&self.get_monitor_update_payload())
+                    .send()
+                    .await
+                {
+                    Ok(resp) if resp.status().is_success() => {
+                        info!("Monitor enriched successful");
+                    }
+                    Ok(resp) => {
+                        if !resp.status().is_success() {
+                            error!(
+                                "Monitor enrichment failed {}: {}",
+                                resp.status(),
+                                resp.text().await.unwrap_or_default()
+                            );
+                        }
+                    }
+                    Err(err) => {
+                        error!("Failed to enrich Cronitor monitor: {err}");
+                    }
+                }
+            }
+        }
+    }
+
+    /// Internal methods for Cronitor
+    impl Cronitor {
+        pub fn build_ping_url(
+            &self,
+            state: PingState,
+            status_code: u16,
+            message: Option<&str>,
+        ) -> String {
+            let mut url = format!(
+                "{}/{}?state={}&series={}&status_code={}&env={}&host={}",
+                self.config.cronitor_base_url,
+                self.config.monitor_name,
+                state.as_str(),
+                self.series_id,
+                status_code,
+                self.config.env,
+                self.host
+            );
+            if let Some(msg) = message {
+                url.push_str("&message=");
+                url.push_str(&urlencoding::encode(msg));
+            }
+            url
+        }
+
+        pub fn get_monitor_update_payload(&self) -> serde_json::Value {
+            let mut monitor = serde_json::Map::new();
+            monitor.insert("type".into(), json!("job"));
+            monitor.insert("key".into(), json!(self.config.monitor_name));
+
+            if let Some(consecutive_failures) = self.config.consecutive_failures {
+                monitor.insert("failure_tolerance".into(), json!(consecutive_failures));
+            }
+
+            if let Some(schedule) = self.config.schedule.clone() {
+                monitor.insert("schedule".into(), json!(schedule));
+            }
+
+            
+            if let (Some(consecutive_missing), Some(_)) = (self.config.consecutive_missing, self.config.schedule.clone()) {
+                monitor.insert("schedule_tolerance".into(), json!(consecutive_missing));
+            }
+            
+            if let Some(group) = self.config.monitor_group.clone() {
+                monitor.insert("group".into(), json!(group));
+            }
+
+            // always include the duration assertion
+            let mut assertions: Vec<String> = vec![format!(
+                "metric.duration < {}s",
+                self.config.timeout_seconds * 2
+            )];
+
+            if let Some(min_success_freq) = self.config.min_success_freq {
+                assertions.push(format!("job.completes < {min_success_freq} minute"));
+            }
+            monitor.insert("assertions".into(), json!(assertions));
+
+            json!({ "monitors": [serde_json::Value::Object(monitor)] })
+        }
+    }
+}
+
+pub mod probes {
+    use anyhow::{Context, Result};
+    use reqwest::Client;
+    use serde_json::json;
+    use std::time::Duration;
+    use tracing::info;
+
+    use super::{cli::Config, ProbeResult};
+
+    // Type of LLM endpoint to probe
+    #[derive(Debug, Clone, Copy, PartialEq, clap::ValueEnum)]
+    pub enum Type {
+        #[value(name = "openai-chat-completion")]
+        OpenAIChatCompletion,
+        #[value(name = "openai-embedding")]
+        OpenAIEmbedding,
+        #[value(name = "newman")]
+        Newman,
+    }
+
+    impl From<Type> for clap::builder::OsStr {
+        fn from(value: Type) -> Self {
+            match value {
+                Type::OpenAIChatCompletion => "openai-chat-completion".into(),
+                Type::OpenAIEmbedding => "openai-embedding".into(),
+                Type::Newman => "newman".into(),
+            }
+        }
+    }
+
+    /// LLM endpoint probe functionality
+    pub struct OpenAI {
+        client: Client,
+        config: Config,
+    }
+
+    /// LLM probe implementation
+    #[async_trait::async_trait]
+    impl super::Probe for OpenAI {
+        fn new(config: Config) -> Result<Self> {
+            let client = Client::builder()
+                .timeout(Duration::from_secs(config.timeout_seconds))
+                .build()
+                .context("building reqwest client")?;
+
+            Ok(OpenAI { client, config })
+        }
+
+        async fn probe(&self) -> ProbeResult {
+            let endpoint = self.build_endpoint_url();
+            let payload = self.build_payload();
+
+            info!("Querying {endpoint}");
+
+            match self.client.post(&endpoint).json(&payload).send().await {
+                Ok(resp) => {
+                    let status = resp.status();
+                    let body = resp.text().await.unwrap_or_default();
+                    info!("Response body: {body}");
+
+                    if status.is_success() {
+                        ProbeResult::Success
+                    } else {
+                        ProbeResult::HttpError(status.as_u16())
+                    }
+                }
+                Err(e) if e.is_timeout() => ProbeResult::Timeout,
+                Err(e) => ProbeResult::NetworkError(e.to_string()),
+            }
+        }
+    }
+
+    /// Internal methods for OpenAI probe
+    impl OpenAI {
+        pub fn build_endpoint_url(&self) -> String {
+            match self.config.endpoint_type {
+                Type::OpenAIChatCompletion => {
+                    format!("{}/v1/chat/completions", self.config.server_url)
+                }
+                Type::OpenAIEmbedding => format!("{}/v1/embeddings", self.config.server_url),
+                _ => panic!("Unsupported endpoint type"),
+            }
+        }
+
+        pub fn build_payload(&self) -> serde_json::Value {
+            match self.config.endpoint_type {
+                Type::OpenAIChatCompletion => json!({
+                    "model": self.config.model_name,
+                    "messages": [{ "role": "user", "content": "test" }],
+                    "max_tokens": 1,
+                    "priority": -100
+                }),
+                Type::OpenAIEmbedding => json!({
+                    "model": self.config.model_name,
+                    "input": "test",
+                    "priority": -100
+                }),
+                _ => panic!("Unsupported endpoint type"),
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{exporters::Cronitor, probes::{OpenAI, Type as EndpointType}, cli::Config, Export, Probe, Monitor, PingState, ProbeResult};
     use httpmock::prelude::*;
     use serde_json::json;
 
     #[test]
     fn test_cronitor_client_creation() {
         let config = Config::default();
-        let client = CronitorClient::new(config);
+        let client = Cronitor::new(config);
         assert!(client.is_ok());
     }
 
     #[test]
     fn test_cronitor_ping_url_construction_without_message() {
         let config = Config::default();
-        let client = CronitorClient::new(config).unwrap();
+        let client = Cronitor::new(config).unwrap();
 
         let url = client.build_ping_url(PingState::Run, 0, None);
 
@@ -441,7 +518,7 @@ mod tests {
     #[test]
     fn test_cronitor_ping_url_construction_with_message() {
         let config = Config::default();
-        let client = CronitorClient::new(config).unwrap();
+        let client = Cronitor::new(config).unwrap();
 
         let url = client.build_ping_url(PingState::Fail, 500, Some("Test error"));
 
@@ -455,7 +532,7 @@ mod tests {
     #[test]
     fn test_cronitor_ping_url_special_characters() {
         let config = Config::default();
-        let client = CronitorClient::new(config).unwrap();
+        let client = Cronitor::new(config).unwrap();
 
         let url = client.build_ping_url(PingState::Fail, 500, Some("Error: 500 & timeout!"));
 
@@ -465,18 +542,18 @@ mod tests {
     #[test]
     fn test_llm_probe_creation() {
         let config = Config::default();
-        let probe = LLMProbe::new(config);
+        let probe = OpenAI::new(config);
         assert!(probe.is_ok());
     }
 
     #[test]
     fn test_llm_probe_chat_endpoint_url() {
         let config = Config {
-            endpoint_type: EndpointType::ChatCompletion,
+            endpoint_type: EndpointType::OpenAIChatCompletion,
             server_url: "https://api.openai.com".to_string(),
             ..Default::default()
         };
-        let probe = LLMProbe::new(config).unwrap();
+        let probe = OpenAI::new(config).unwrap();
 
         let url = probe.build_endpoint_url();
         assert_eq!(url, "https://api.openai.com/v1/chat/completions");
@@ -485,11 +562,11 @@ mod tests {
     #[test]
     fn test_llm_probe_embedding_endpoint_url() {
         let config = Config {
-            endpoint_type: EndpointType::Embedding,
+            endpoint_type: EndpointType::OpenAIEmbedding,
             server_url: "https://api.example.com".to_string(),
             ..Default::default()
         };
-        let probe = LLMProbe::new(config).unwrap();
+        let probe = OpenAI::new(config).unwrap();
 
         let url = probe.build_endpoint_url();
         assert_eq!(url, "https://api.example.com/v1/embeddings");
@@ -498,11 +575,11 @@ mod tests {
     #[test]
     fn test_llm_probe_chat_payload() {
         let config = Config {
-            endpoint_type: EndpointType::ChatCompletion,
+            endpoint_type: EndpointType::OpenAIChatCompletion,
             model_name: "a-piece-of-cheese".to_string(),
             ..Default::default()
         };
-        let probe = LLMProbe::new(config).unwrap();
+        let probe = OpenAI::new(config).unwrap();
 
         let payload = probe.build_payload();
         let expected = json!({
@@ -518,11 +595,11 @@ mod tests {
     #[test]
     fn test_llm_probe_embedding_payload() {
         let config = Config {
-            endpoint_type: EndpointType::Embedding,
+            endpoint_type: EndpointType::OpenAIEmbedding,
             model_name: "text-embedding-ada-002".to_string(),
             ..Default::default()
         };
-        let probe = LLMProbe::new(config).unwrap();
+        let probe = OpenAI::new(config).unwrap();
 
         let payload = probe.build_payload();
         let expected = json!({
@@ -555,12 +632,12 @@ mod tests {
 
         let config = Config {
             server_url: server.base_url(),
-            endpoint_type: EndpointType::ChatCompletion,
+            endpoint_type: EndpointType::OpenAIChatCompletion,
             model_name: "gpt-4".to_string(),
             ..Default::default()
         };
 
-        let probe = LLMProbe::new(config).unwrap();
+        let probe = OpenAI::new(config).unwrap();
         let result = probe.probe().await;
 
         assert_eq!(result, ProbeResult::Success);
@@ -582,12 +659,12 @@ mod tests {
 
         let config = Config {
             server_url: server.base_url(),
-            endpoint_type: EndpointType::Embedding,
+            endpoint_type: EndpointType::OpenAIEmbedding,
             model_name: "text-embedding-ada-002".to_string(),
             ..Default::default()
         };
 
-        let probe = LLMProbe::new(config).unwrap();
+        let probe = OpenAI::new(config).unwrap();
         let result = probe.probe().await;
 
         match result {
@@ -608,7 +685,7 @@ mod tests {
             ..Default::default()
         };
 
-        let probe = LLMProbe::new(config).unwrap();
+        let probe = OpenAI::new(config).unwrap();
         let result = probe.probe().await;
 
         assert!(matches!(result, ProbeResult::Timeout));
@@ -621,7 +698,7 @@ mod tests {
             ..Default::default()
         };
 
-        let probe = LLMProbe::new(config).unwrap();
+        let probe = OpenAI::new(config).unwrap();
         let result = probe.probe().await;
 
         match result {

--- a/ai-vitals/src/main.rs
+++ b/ai-vitals/src/main.rs
@@ -1,4 +1,4 @@
-use ai_vitals::{Config, Monitor};
+use ai_vitals::{cli::Config, Monitor};
 use anyhow::{Context, Result};
 use clap::Parser;
 use std::process::exit;

--- a/ai-vitals/src/main.rs
+++ b/ai-vitals/src/main.rs
@@ -1,4 +1,4 @@
-use ai_vitals::{cli::Config, Monitor};
+use ai_vitals::{Monitor, cli::Config};
 use anyhow::{Context, Result};
 use clap::Parser;
 use std::process::exit;

--- a/ai-vitals/test-collection.json
+++ b/ai-vitals/test-collection.json
@@ -1,0 +1,198 @@
+{
+  "info": {
+    "name": "Test API Collection",
+    "description": "Minimal collection for unit tests",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Health Check",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Status code is 200\", function () {",
+              "    pm.response.to.have.status(200);",
+              "});",
+              "",
+              "pm.test(\"Response time is less than 1000ms\", function () {",
+              "    pm.expect(pm.response.responseTime).to.be.below(1000);",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/health",
+          "host": ["{{base_url}}"],
+          "path": ["health"]
+        },
+        "description": "Simple health check endpoint"
+      }
+    },
+    {
+      "name": "Get User",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Status code is 200\", function () {",
+              "    pm.response.to.have.status(200);",
+              "});",
+              "",
+              "pm.test(\"Response has user id\", function () {",
+              "    var jsonData = pm.response.json();",
+              "    pm.expect(jsonData).to.have.property('id');",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": "Bearer {{api_token}}",
+            "type": "text"
+          }
+        ],
+        "url": {
+          "raw": "{{base_url}}/api/v1/users/123",
+          "host": ["{{base_url}}"],
+          "path": ["api", "v1", "users", "123"]
+        },
+        "description": "Get a specific user by ID"
+      }
+    },
+    {
+      "name": "Create Resource",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Status code is 201\", function () {",
+              "    pm.response.to.have.status(201);",
+              "});",
+              "",
+              "pm.test(\"Response has created resource\", function () {",
+              "    var jsonData = pm.response.json();",
+              "    pm.expect(jsonData).to.have.property('id');",
+              "    pm.expect(jsonData.name).to.eql('Test Resource');",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        },
+        {
+          "listen": "prerequest",
+          "script": {
+            "exec": [
+              "// Set a timestamp for unique naming",
+              "pm.collectionVariables.set('timestamp', new Date().getTime());"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          },
+          {
+            "key": "Authorization",
+            "value": "Bearer {{api_token}}"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n    \"name\": \"Test Resource\",\n    \"description\": \"Created at {{timestamp}}\",\n    \"active\": true\n}"
+        },
+        "url": {
+          "raw": "{{base_url}}/api/v1/resources",
+          "host": ["{{base_url}}"],
+          "path": ["api", "v1", "resources"]
+        },
+        "description": "Create a new resource"
+      }
+    },
+    {
+      "name": "Delete Resource",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Status code is 204\", function () {",
+              "    pm.response.to.have.status(204);",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "DELETE",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": "Bearer {{api_token}}"
+          }
+        ],
+        "url": {
+          "raw": "{{base_url}}/api/v1/resources/456",
+          "host": ["{{base_url}}"],
+          "path": ["api", "v1", "resources", "456"]
+        },
+        "description": "Delete a resource"
+      }
+    }
+  ],
+  "auth": {
+    "type": "bearer",
+    "bearer": [
+      {
+        "key": "token",
+        "value": "{{api_token}}",
+        "type": "string"
+      }
+    ]
+  },
+  "event": [
+    {
+      "listen": "test",
+      "script": {
+        "type": "text/javascript",
+        "exec": [
+          "// Global test - track any failures",
+          "if (pm.response.code >= 400) {",
+          "    pm.collectionVariables.set('has_errors', true);",
+          "}"
+        ]
+      }
+    }
+  ],
+  "variable": [
+    {
+      "key": "timestamp",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "has_errors",
+      "value": "false",
+      "type": "string"
+    }
+  ]
+}


### PR DESCRIPTION
Refactored AI Vitals into exporter and probe format. Monitor now becomes a runtime to systematically run a probe and report result to an exporter. Added a [postman newman](https://learning.postman.com/docs/collections/using-newman-cli/command-line-integration-with-newman/) implementation for the probe